### PR TITLE
Lock everything

### DIFF
--- a/fallaxy.py
+++ b/fallaxy.py
@@ -344,10 +344,12 @@ def get_tar_hash(tar, name):
 def insert_collection(manifest, filename, collection_size, collection_hash):
     if not Namespace.query.filter_by(name=manifest['namespace']).first():
         db.session.add(Namespace(name=manifest['namespace']))
+        db.session.commit()
     namespace = Namespace.query.filter_by(name=manifest['namespace']).first()
 
     if not Collection.query.with_parent(namespace).filter_by(name=manifest['name']).first():
         db.session.add(Collection(name=manifest['name'], namespace=namespace))
+        db.session.commit()
     collection = Collection.query.with_parent(namespace).filter_by(name=manifest['name']).first()
 
     version_kwargs = {}


### PR DESCRIPTION
This PR implements a few things:

1. Locking around all database interactions to avoid issues seen with threading
1. rollback in a few exception cases
1. committing after `.add` and before query to prevent:

    ```
    Cursor needed to be reset because of commit/rollback and can no longer be fetched from
    ```

The app seems to be much more stable after these changes, whereas I could get it to fail pretty reliably before.